### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/dungeon.rs
+++ b/src/dungeon.rs
@@ -38,7 +38,7 @@ impl Dir {
     // iterator over direction variants
     pub fn iterator() -> Iter<'static, Dir> {
         static DIR: [Dir;  4] = [Dir::North, Dir::South, Dir::East, Dir::West];
-        DIR.into_iter()
+        DIR.iter()
     }
 
     pub fn get_random_dir<'a>()-> &'a Dir {


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.